### PR TITLE
Make the gem work with latest grape-api gem

### DIFF
--- a/lib/grape/kaminari/max_value_validator.rb
+++ b/lib/grape/kaminari/max_value_validator.rb
@@ -1,7 +1,7 @@
 module Grape
   module Kaminari
     base = if post_0_9_0_grape?
-             Grape::Validations::Base
+             Grape::Validations::Validators::Base
            else
              Grape::Validations::SingleOptionValidator
            end


### PR DESCRIPTION
The validations `Base` class now has a new module in the hierarchy, and hence make the class point to the correct base class

* Rename `Grape::Validations::Base` -> `Grape::Validations::Validators::Base`